### PR TITLE
Add a pseudo element to the links list that appears on hover.

### DIFF
--- a/css/first-template.css
+++ b/css/first-template.css
@@ -140,9 +140,30 @@ body {
   text-decoration: none;
   color: #333;
   transition: 0.3s;
+  position: relative;
+  z-index: 1; /*Create a new stacking context*/
 }
 .header .links ul li a:hover {
   padding-left: 25px;
+}
+/*
+  Create a pseudo element that appears on hover.
+*/
+.header .links ul li a::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1; 
+  background-color: #ddd; 
+  transform-origin: 0% 50%;
+  transform: scaleX(0);
+  transition: transform .4s ;
+}
+.header .links ul li a:hover::after{
+  transform: scaleX(1);
 }
 .header .links ul li:not(:last-child) a {
   border-bottom: 1px solid #ddd;


### PR DESCRIPTION
In the links list I added to the element " a "  value of **position :relative** and also a value of **z-index: 1** which created a new stacking context that will make the fake element appear above the background of the original element but under the content of the original element and I added a **pseudo element** that is initially hidden due to scaleX (0) and when hovering over the original element the **pseudo element** will appear due to scaleX (1) .